### PR TITLE
CAF-2014: Split lines in quoted emails not getting marked as split lines

### DIFF
--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -131,7 +131,7 @@ RE_ORIGINAL_MESSAGE = re.compile(u'[\s]*[-]+[ ]*({})[ ]*[-]+'.format(
         'Oprindelig meddelelse',
     ))), re.I)
 
-RE_FROM_COLON_OR_DATE_COLON = re.compile(u'(_+\r?\n)?[\s]*(:?[*]?{})[\s]?:[*]? .*'.format(
+RE_FROM_COLON_OR_DATE_COLON = re.compile(u'(_+\r?\n)?[\s]*(:?[*]?{})[\s]?:[*]?.*'.format(
     u'|'.join((
         # "From" in different languages.
         'From', 'Van', 'De', 'Von', 'Fra', u'Från',

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -469,10 +469,31 @@ def split_emails(msg):
     lines = msg_body.splitlines()[:MAX_LINES_COUNT]
     markers = mark_message_lines(lines)
 
+    markers = _mark_quoted_email_splitlines(markers, lines)
+
     # we don't want splitlines in header blocks
     markers = _correct_splitlines_in_headers(markers, lines)
 
     return markers
+
+
+def _mark_quoted_email_splitlines(markers, lines):
+    """
+    When there are headers indented with '>' characters, we will attempt to identify if the header is a splitline header
+    using a slightly altered SPLITTER_PATTERNS list and mark it as 's'.
+    """
+    # Create a list of markers to easily alter specific characters
+    markerlist = list(markers)
+    for i, line in enumerate(lines):
+        if markerlist[i] != 'm':
+            continue
+        for pattern in SPLITTER_PATTERNS:
+            matcher = re.search(pattern, line)
+            if matcher:
+                markerlist[i] = 's'
+                break
+
+    return "".join(markerlist)
 
 
 def _correct_splitlines_in_headers(markers, lines):

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -188,7 +188,7 @@ def extract_from(msg_body, content_type='text/plain'):
     return msg_body
 
 
-def mark_message_lines(lines):
+def mark_message_lines(lines, ignore_initial_spaces=False):
     """Mark message lines with markers to distinguish quotation lines.
 
     Markers:
@@ -204,6 +204,8 @@ def mark_message_lines(lines):
     markers = ['e' for _ in lines]
     i = 0
     while i < len(lines):
+        if ignore_initial_spaces:
+            lines[i] = lines[i].lstrip(' ')
         if not lines[i].strip():
             markers[i] = 'e'  # empty line
         elif QUOT_PATTERN.match(lines[i]):
@@ -480,10 +482,11 @@ def split_emails(msg):
     Return the corrected markers
     """
     msg_body = _replace_link_brackets(msg)
+    ignore_initial_spaces = True
 
     # don't process too long messages
     lines = msg_body.splitlines()[:MAX_LINES_COUNT]
-    markers = mark_message_lines(lines)
+    markers = mark_message_lines(lines, ignore_initial_spaces)
 
     markers = _mark_quoted_email_splitlines(markers, lines)
 

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -509,7 +509,10 @@ def _correct_splitlines_in_headers(markers, lines):
                 if bool(re.search(RE_HEADER, lines[i])):
                     in_header_block = True
             else:
-                m = 't'
+                if QUOT_PATTERN.match(lines[i]):
+                    m = 'm'
+                else:
+                    m = 't'
 
         # If the line is not a header line, set in_header_block false.
         if not bool(re.search(RE_HEADER, lines[i])):

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -188,7 +188,20 @@ def extract_from(msg_body, content_type='text/plain'):
     return msg_body
 
 
-def mark_message_lines(lines, ignore_initial_spaces=False):
+def remove_initial_spaces_and_mark_message_lines(lines):
+    """
+    Removes the initial spaces in each line before marking message lines.
+
+    This ensures headers can be identified if they are indented with spaces.
+    """
+    i = 0
+    while i < len(lines):
+        lines[i] = lines[i].lstrip(' ')
+        i += 1
+    return mark_message_lines(lines)
+
+
+def mark_message_lines(lines):
     """Mark message lines with markers to distinguish quotation lines.
 
     Markers:
@@ -204,8 +217,6 @@ def mark_message_lines(lines, ignore_initial_spaces=False):
     markers = ['e' for _ in lines]
     i = 0
     while i < len(lines):
-        if ignore_initial_spaces:
-            lines[i] = lines[i].lstrip(' ')
         if not lines[i].strip():
             markers[i] = 'e'  # empty line
         elif QUOT_PATTERN.match(lines[i]):
@@ -489,7 +500,7 @@ def split_emails(msg):
 
     # don't process too long messages
     lines = msg_body.splitlines()[:MAX_LINES_COUNT]
-    markers = mark_message_lines(lines, ignore_initial_spaces=True)
+    markers = remove_initial_spaces_and_mark_message_lines(lines)
 
     markers = _mark_quoted_email_splitlines(markers, lines)
 

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -479,8 +479,8 @@ def split_emails(msg):
 
 def _mark_quoted_email_splitlines(markers, lines):
     """
-    When there are headers indented with '>' characters, we will attempt to identify if the header is a splitline header
-    using a slightly altered SPLITTER_PATTERNS list and mark it as 's'.
+    When there are headers indented with '>' characters, this method will attempt to identify if the header is a
+    splitline header. If it is, then we mark it with 's' instead of leaving it as 'm' and return the new markers.
     """
     # Create a list of markers to easily alter specific characters
     markerlist = list(markers)

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -482,11 +482,10 @@ def split_emails(msg):
     Return the corrected markers
     """
     msg_body = _replace_link_brackets(msg)
-    ignore_initial_spaces = True
 
     # don't process too long messages
     lines = msg_body.splitlines()[:MAX_LINES_COUNT]
-    markers = mark_message_lines(lines, ignore_initial_spaces)
+    markers = mark_message_lines(lines, ignore_initial_spaces=True)
 
     markers = _mark_quoted_email_splitlines(markers, lines)
 

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -300,8 +300,10 @@ def preprocess(msg_body, delimiter, content_type='text/plain'):
 
 
 def _replace_link_brackets(msg_body):
-    """Normalize links i.e. replace '<', '>' wrapping the link with some symbols
-    so that '>' closing the link couldn't be mistakenly taken for quotation marker.
+    """
+    Normalize links i.e. replace '<', '>' wrapping the link with some symbols
+    so that '>' closing the link couldn't be mistakenly taken for quotation
+    marker.
 
     Converts msg_body into a unicode
     """
@@ -320,7 +322,8 @@ def _replace_link_brackets(msg_body):
 
 
 def _wrap_splitter_with_newline(msg_body, delimiter, content_type='text/plain'):
-    """Splits line in two if splitter pattern preceded by some text on the same
+    """
+    Splits line in two if splitter pattern preceded by some text on the same
     line (done only for 'On <date> <person> wrote:' pattern.
     """
     def splitter_wrapper(splitter):
@@ -473,11 +476,12 @@ def _extract_from_html(msg_body):
 
 def split_emails(msg):
     """
-    Given a message (which may consist of an email conversation thread with multiple emails), mark the lines to identify
-     split lines, content lines and empty lines.
+    Given a message (which may consist of an email conversation thread with
+    multiple emails), mark the lines to identify split lines, content lines and
+    empty lines.
 
-    Correct the split line markers inside header blocks. Header blocks are identified by the regular expression
-    RE_HEADER.
+    Correct the split line markers inside header blocks. Header blocks are
+    identified by the regular expression RE_HEADER.
 
     Return the corrected markers
     """
@@ -497,8 +501,9 @@ def split_emails(msg):
 
 def _mark_quoted_email_splitlines(markers, lines):
     """
-    When there are headers indented with '>' characters, this method will attempt to identify if the header is a
-    splitline header. If it is, then we mark it with 's' instead of leaving it as 'm' and return the new markers.
+    When there are headers indented with '>' characters, this method will
+    attempt to identify if the header is a splitline header. If it is, then we
+    mark it with 's' instead of leaving it as 'm' and return the new markers.
     """
     # Create a list of markers to easily alter specific characters
     markerlist = list(markers)
@@ -515,13 +520,15 @@ def _mark_quoted_email_splitlines(markers, lines):
 
 
 def _correct_splitlines_in_headers(markers, lines):
-    """Corrects markers by removing splitlines deemed to be inside header blocks"""
+    """
+    Corrects markers by removing splitlines deemed to be inside header blocks.
+    """
     updated_markers = ""
     i = 0
     in_header_block = False
 
     for m in markers:
-        # Only set in_header_block flag true when we hit an 's' and the line is a header.
+        # Only set in_header_block flag when we hit an 's' and line is a header
         if m == 's':
             if not in_header_block:
                 if bool(re.search(RE_HEADER, lines[i])):

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -700,36 +700,48 @@ def test_standard_replies():
 
 def test_split_email():
     msg = """From: Mr. X
-Date: 24 February 2016
-To: Mr. Y
-Subject: Hi
-Attachments: none
-Goodbye.
-From: Mr. Y
-To: Mr. X
-Date: 24 February 2016
-Subject: Hi
-Attachments: none
+    Date: 24 February 2016
+    To: Mr. Y
+    Subject: Hi
+    Attachments: none
+    Goodbye.
+    From: Mr. Y
+    To: Mr. X
+    Date: 24 February 2016
+    Subject: Hi
+    Attachments: none
 
-Hello.
+    Hello.
 
--- Original Message --
-On 24th February 2016 at 09.32am Conal Wrote:
-Hey!
+        On 24th February 2016 at 09.32am, Conal Wrote:
 
-> Date: Mon, 2 Apr 2012 17:44:22 +0400
-> Subject: Test
-> From: bob@xxx.mailgun.org
-> To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net; xxx@nyc.rr.com
->
-> Hi
->
-> > From: bob@xxx.mailgun.org
-> > To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net; xxx@nyc.rr.com
-> > Date: Mon, 2 Apr 2012 17:44:22 +0400
-> > Subject: Test
-> > Hi
+        Hey!
+
+        On Mon, 2016-10-03 at 09:45 -0600, Stangel, Dan wrote:
+        > Mohan,
+        >
+        > We have not yet migrated the systems.
+        >
+        > Dan
+        >
+        > > -----Original Message-----
+        > > Date: Mon, 2 Apr 2012 17:44:22 +0400
+        > > Subject: Test
+        > > From: bob@xxx.mailgun.org
+        > > To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net; xxx@nyc.rr.com
+        > >
+        > > Hi
+        > >
+        > > > From: bob@xxx.mailgun.org
+        > > > To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net; xxx@nyc.rr.com
+        > > > Date: Mon, 2 Apr 2012 17:44:22 +0400
+        > > > Subject: Test
+        > > > Hi
+        > > >
+        > >
+        >
+        >
 """
-    expected_markers = "stttttsttttetesttesmmmmmmsmmmm"
+    expected_markers = "stttttsttttetetetesmmmmmmssmmmmmmsmmmmmmmm"
     markers = quotations.split_emails(msg)
     eq_(markers, expected_markers)

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -713,7 +713,7 @@ def test_split_email():
 
     Hello.
 
-        On 24th February 2016 at 09.32am, Conal Wrote:
+        On 24th February 2016 at 09.32am, Conal wrote:
 
         Hey!
 
@@ -742,6 +742,6 @@ def test_split_email():
         >
         >
 """
-    expected_markers = "stttttsttttetetetesmmmmmmssmmmmmmsmmmmmmmm"
+    expected_markers = "stttttsttttetesetesmmmmmmssmmmmmmsmmmmmmmm"
     markers = quotations.split_emails(msg)
     eq_(markers, expected_markers)

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -730,6 +730,6 @@ Hey!
 > > Subject: Test
 > > Hi
 """
-    expected_markers = "stttttsttttetesttesmtmmmmsmtmm"
+    expected_markers = "stttttsttttetesttesmmmmmmsmmmm"
     markers = quotations.split_emails(msg)
     eq_(markers, expected_markers)

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -716,7 +716,14 @@ Hello.
 -- Original Message --
 On 24th February 2016 at 09.32am Conal Wrote:
 Hey!
+
+> Date: Mon, 2 Apr 2012 17:44:22 +0400
+> Subject: Test
+> From: bob@xxx.mailgun.org
+> To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net; xxx@nyc.rr.com
+>
+> Hi
 """
-    expected_markers = "stttttsttttetestt"
+    expected_markers = "stttttsttttetesttesmtmmm"
     markers = quotations.split_emails(msg)
     eq_(markers, expected_markers)

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -723,7 +723,13 @@ Hey!
 > To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net; xxx@nyc.rr.com
 >
 > Hi
+>
+> > From: bob@xxx.mailgun.org
+> > To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net; xxx@nyc.rr.com
+> > Date: Mon, 2 Apr 2012 17:44:22 +0400
+> > Subject: Test
+> > Hi
 """
-    expected_markers = "stttttsttttetesttesmtmmm"
+    expected_markers = "stttttsttttetesttesmtmmmmsmtmm"
     markers = quotations.split_emails(msg)
     eq_(markers, expected_markers)


### PR DESCRIPTION
This is to merge into my own fork's master.

Added new method which marks as splitlines, lines which are splitlines but start with email quotation indents ("> ").

Added to the existing split_email() test, testing the new functionality.

Note: Is it fine that 'mmmmmm' can become 'smtmmm' - the third line is marked as a split line by our new method, but is then converted to a 't' as it is in a header block?